### PR TITLE
Update package.sh to work with addon-builder repository

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -4,7 +4,8 @@ rm -rf node_modules
 if [ -z "${ADDON_ARCH}" ]; then
   TARFILE_SUFFIX=
 else
-  TARFILE_SUFFIX="-${ADDON_ARCH}"
+  NODE_VERSION="$(node --version)"
+  TARFILE_SUFFIX="-${ADDON_ARCH}-${NODE_VERSION/\.*/}"
 fi
 if [ "${ADDON_ARCH}" == "linux-arm" ]; then
   # We assume that CC and CXX are pointing to the cross compilers

--- a/package.sh
+++ b/package.sh
@@ -1,13 +1,27 @@
 #!/bin/bash
 
 rm -rf node_modules
-yarn install --production
+if [ -z "${ADDON_ARCH}" ]; then
+  TARFILE_SUFFIX=
+else
+  TARFILE_SUFFIX="-${ADDON_ARCH}"
+fi
+if [ "${ADDON_ARCH}" == "linux-arm" ]; then
+  # We assume that CC and CXX are pointing to the cross compilers
+  yarn --ignore-scripts --production
+  npm rebuild --arch=armv6l --target_arch=arm
+else
+  yarn install --production
+fi
+
 rm -f SHA256SUMS
 sha256sum package.json *.js LICENSE > SHA256SUMS
 find node_modules -type f -exec sha256sum {} \; >> SHA256SUMS
-TARFILE=$(npm pack)
+TARFILE="$(npm pack)"
 tar xzf ${TARFILE}
+rm ${TARFILE}
+TARFILE_ARCH="${TARFILE/.tgz/${TARFILE_SUFFIX}.tgz}"
 cp -r node_modules ./package
-tar czf ${TARFILE} package
+tar czf ${TARFILE_ARCH} package
 rm -rf package
-echo "Created ${TARFILE}"
+echo "Created ${TARFILE_ARCH}"


### PR DESCRIPTION
If you run package.sh it should behave as before.
If you set ADDON_ARCH then that will be appended to the tarball name
If ADDON_ARCH is set to linux-arm then it will invoke npm as if it were using a cross compiler.