### PR TITLE
Fix a bug observed while processing the tamper sensor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zwave-adapter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Z-Wave adapter plugin for Mozilla IoT Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/zwave-property.js
+++ b/zwave-property.js
@@ -84,7 +84,7 @@ class ZWaveProperty extends Property {
         motion = true;
         break;
     }
-    if (motion === undefined) {
+    if (typeof motion === 'undefined') {
       motion = false;
     }
     return [motion, motion.toString()];
@@ -100,7 +100,7 @@ class ZWaveProperty extends Property {
         tamper = true;
         break;
     }
-    if (tamper === undefined) {
+    if (typeof tamper === 'undefined') {
       tamper = false;
     }
     return [tamper, tamper.toString()];

--- a/zwave-property.js
+++ b/zwave-property.js
@@ -84,6 +84,9 @@ class ZWaveProperty extends Property {
         motion = true;
         break;
     }
+    if (motion === undefined) {
+      motion = false;
+    }
     return [motion, motion.toString()];
   }
 
@@ -96,6 +99,9 @@ class ZWaveProperty extends Property {
       case ALARM_EVENT_HOME_SECURITY_TAMPER:
         tamper = true;
         break;
+    }
+    if (tamper === undefined) {
+      tamper = false;
     }
     return [tamper, tamper.toString()];
   }


### PR DESCRIPTION
I saw this today while pairing with the Aeotec multisensor.
```
2018-05-16 17:23:42.603 zwave: node4 valueChanged: 4-113-1-0:Alarm Type = 0
2018-05-16 17:23:42.604 zwave: node4 valueChanged: 4-113-1-1:Alarm Level = 0
2018-05-16 17:23:42.605 zwave: node4 valueChanged: 4-113-1-2:SourceNodeId = 0
2018-05-16 17:23:42.606 zwave: node4 valueChanged: 4-113-1-10:Burglar = 8
2018-05-16 17:23:46.204 zwave: node4: timeout
2018-05-16 17:23:46.205 zwave: Controller Command feedback: ControllerCommand - Starting node0 retVal:1 state:0
2018-05-16 17:23:46.213 zwave: Controller Command feedback: ControllerCommand - InProgress node0 retVal:6 state:0
2018-05-16 17:23:46.336 zwave: Controller Command feedback: ControllerCommand - Completed node0 retVal:7 state:0
2018-05-16 17:23:46.336 zwave: Controller Command feedback: ControllerCommand - Starting node0 retVal:1 state:0
2018-05-16 17:23:46.349 zwave: Controller Command feedback: ControllerCommand - InProgress node0 retVal:6 state:0
2018-05-16 17:23:46.431 thing-url: getValue for property text for: Text display returning moz://a iot
2018-05-16 17:23:46.689 zwave: Controller Command feedback: ControllerCommand - Completed node0 retVal:7 state:0
2018-05-16 17:23:46.730 debug: Got: propertyChanged notification for: TP Link Red Bulb property: current value: 0.013302
2018-05-16 17:23:46.731 debug: Got: propertyChanged notification for: TP Link Red Bulb property: voltage value: 122.032051
2018-05-16 17:23:46.741 zwave: node4 valueChanged: 4-115-1-0:Powerlevel = Normal dB
2018-05-16 17:23:46.743 zwave: node4 valueChanged: 4-115-1-1:Timeout = 0 seconds
2018-05-16 17:23:46.788 zwave: node4 valueChanged: 4-132-1-0:Wake-up Interval = 3600 Seconds
2018-05-16 17:23:46.834 zwave: node4 valueChanged: 4-48-1-0:Sensor = true
2018-05-16 17:23:47.324 zwave: node4 valueChanged: 4-49-1-1:Temperature = 76.2 F
2018-05-16 17:23:49.493 zigbee: zb-f0d1b800000297d6-onOffSwitch property: on profileId: 0104 endpoint: 1 clusterId: 0006 report value: off (0)
2018-05-16 17:23:49.496 debug: Got: propertyChanged notification for: zb-f0d1b800000297d6-onOffSwitch property: on value: false
2018-05-16 17:23:51.144 zwave: node4 valueChanged: 4-49-1-1:Temperature = 76.2 F
2018-05-16 17:23:51.304 zwave: node4 valueChanged: 4-49-1-5:Relative Humidity = 39 %
2018-05-16 17:23:52.163 zwave: node4 valueChanged: 4-49-1-3:Luminance = 38 lux
2018-05-16 17:23:52.282 zwave: node4 valueChanged: 4-49-1-27:Ultraviolet = 0
2018-05-16 17:23:53.219 debug: Got: propertyChanged notification for: TP Link Red Bulb property: current value: 0.013135
2018-05-16 17:23:53.220 debug: Got: propertyChanged notification for: TP Link Red Bulb property: voltage value: 122.021069
2018-05-16 17:23:53.221 thing-url: getValue for property text for: Text display returning moz://a iot
2018-05-16 17:23:54.663 zwave: node4 valueChanged: 4-128-1-0:Battery Level = 100 %
2018-05-16 17:23:54.665 zwave: Setting device zwave-fb8d38d6-4 config instance: 1index: 5to value: 1
2018-05-16 17:23:54.673 zwave: /home/pi/.mozilla-iot/addons/zwave-adapter/zwave-property.js:100
2018-05-16 17:23:54.673 zwave:     return [tamper, tamper.toString()];
2018-05-16 17:23:54.674 zwave:                            ^
2018-05-16 17:23:54.674 zwave: 
2018-05-16 17:23:54.674 zwave: TypeError: Cannot read property 'toString' of undefined
2018-05-16 17:23:54.674 zwave:     at ZWaveProperty.parseAlarmTamperZwValue (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-property.js:100:28)
2018-05-16 17:23:54.675 zwave:     at new ZWaveProperty (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-property.js:65:37)
2018-05-16 17:23:54.675 zwave:     at ZWaveClassifier.addProperty (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-classifier.js:260:20)
2018-05-16 17:23:54.675 zwave:     at ZWaveClassifier.addAlarmProperty (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-classifier.js:277:10)
2018-05-16 17:23:54.675 zwave:     at ZWaveClassifier.classifyInternal (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-classifier.js:200:12)
2018-05-16 17:23:54.676 zwave:     at ZWaveClassifier.classify (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-classifier.js:144:10)
2018-05-16 17:23:54.676 zwave:     at ZWaveAdapter.handleDeviceAdded (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-adapter.js:133:23)
2018-05-16 17:23:54.676 zwave:     at ZWaveAdapter.nodeReady (/home/pi/.mozilla-iot/addons/zwave-adapter/zwave-adapter.js:262:14)
2018-05-16 17:23:54.676 zwave:     at emitTwo (events.js:126:13)
2018-05-16 17:23:54.677 zwave:     at OZW.emit (events.js:214:7)
2018-05-16 17:23:54.701 Plugin: zwave-adapter died, code = 1 restarting...
```
I'm pretty sure that this happens because we haven't yet seen a tamper value from the device when we add the property.