### PR TITLE
Add support for setting network key via Configure

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "schema": {
       "type": "object",
       "required": [
-        "networkKey"
       ],
       "properties": {
         "networkKey": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,21 @@
     },
     "enabled": true,
     "plugin": true,
-    "exec": "{nodeLoader} {path}"
+    "exec": "{nodeLoader} {path}",
+    "config": {
+      "networkKey": ""
+    },
+    "schema": {
+      "type": "object",
+      "required": [
+        "networkKey"
+      ],
+      "properties": {
+        "networkKey": {
+          "type": "string",
+          "default": ""
+        }
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
       "properties": {
         "networkKey": {
           "type": "string",
-          "default": ""
+          "description": "16-byte, comma-separated hex string (0xb4,0xc9,etc...)"
         }
       }
     }

--- a/zwave-adapter.js
+++ b/zwave-adapter.js
@@ -27,6 +27,9 @@ try {
 }
 
 let ZWaveModule;
+// This will get set to the contents of package.json within loadZWaveAdapters(),
+// at which point we can reference config values in the `moziot` section
+let adapterManifest;
 
 const DEBUG = false;
 
@@ -61,11 +64,33 @@ class ZWaveAdapter extends Adapter {
       }
     }
 
-    this.zwave = new ZWaveModule({
+    const zWaveModuleOptions = {
       SaveConfiguration: true,
       ConsoleOutput: false,
       UserPath: logDir,
-    });
+    };
+
+    /* eslint-disable max-len */
+    /**
+     * node-openzwave-shared allows for a cryptographic "network key" to be set
+     * to enable adding devices using ZWave's "security mode" support. The key
+     * is specified as a string containing a 16-byte hex sequence:
+     *
+     * Ex: "0xf7,0xf4,0x95,0xfb,0x81,0x83,0xa2,0xca,0x4e,0xe0,0x75,0x07,0x05,0x51,0x16,0x01"
+     *
+     * DO NOT USE THE ABOVE KEY, IT IS ONLY THERE AS AN EXAMPLE!
+     *
+     * A key can be specified by clicking Configure on this add-on in Gateway.
+     */
+    /* eslint-enable max-len */
+    const networkKey = adapterManifest.moziot.config.networkKey;
+
+    if (networkKey) {
+      console.log('Found NetworkKey, initializing with support for Security Devices'); // eslint-disable-line max-len
+      zWaveModuleOptions.NetworkKey = networkKey;
+    }
+
+    this.zwave = new ZWaveModule(zWaveModuleOptions);
     this.zwave.on('controller command', this.controllerCommand.bind(this));
     this.zwave.on('driver ready', this.driverReady.bind(this));
     this.zwave.on('driver failed', this.driverFailed.bind(this));
@@ -428,6 +453,8 @@ function findZWavePort(callback) {
 }
 
 function loadZWaveAdapters(addonManager, manifest, errorCallback) {
+  adapterManifest = manifest;
+
   try {
     ZWaveModule = require('openzwave-shared');
   } catch (err) {

--- a/zwave-adapter.js
+++ b/zwave-adapter.js
@@ -86,8 +86,14 @@ class ZWaveAdapter extends Adapter {
     const networkKey = adapterManifest.moziot.config.networkKey;
 
     if (networkKey) {
-      console.log('Found NetworkKey, initializing with support for Security Devices'); // eslint-disable-line max-len
-      zWaveModuleOptions.NetworkKey = networkKey;
+      // A regex to validate the required network key format shown above
+      const networkKeyRegex = /^(?:0x[abcdef\d]{2},){15}(?:0x[abcdef\d]{2}){1}$/; // eslint-disable-line max-len
+      if (networkKeyRegex.test(networkKey)) {
+        console.info('Found NetworkKey, initializing with support for Security Devices'); // eslint-disable-line max-len
+        zWaveModuleOptions.NetworkKey = networkKey;
+      } else {
+        console.warn('Found NetworkKey, but invalid format. Ignoring'); // eslint-disable-line max-len
+      }
     }
 
     this.zwave = new ZWaveModule(zWaveModuleOptions);


### PR DESCRIPTION
**node-openzwave-shared** allows for a cryptographic `NetworkKey` config parameter to be specified when an instance is initialized. This enables joining ZWave "security" devices, as per this document:

https://github.com/OpenZWave/node-openzwave-shared/blob/master/README-security.md 

I've updated the **zwave-adapter** add-on to allow for this value to be configured from within Gateway's Add-ons section:

![screen shot 2018-09-27 at 10 52 49 am](https://user-images.githubusercontent.com/5166470/46164685-8123bb00-c243-11e8-9f6e-eb075b9636cb.png)

When a key is configured, the adapter will acknowledge that it's setting it:

```
2018-09-27 10:51:56.340 Loading add-on: zwave-adapter
...snip...
2018-09-27 10:51:57.586 zwave: Found NetworkKey, initializing with support for Security Devices
...snip...
2018-09-27 10:51:57.587 zwave:  Option Overrides : --SaveConfiguration true --ConsoleOutput false --NetworkKey 0xf7,0xf1,0xa0,0xe6,0x69,0xfe,0xbd,0x1d,0x9e,0x1c,0x7f,0xf0,0x94,0x66,0xc1,0x41
```