### PR TITLE
kind of partial door sensor support

### DIFF
--- a/zwave-classifier.js
+++ b/zwave-classifier.js
@@ -365,6 +365,7 @@ class ZWaveClassifier {
       }
 
       case GENERIC_TYPE.SENSOR_BINARY:
+      case GENERIC_TYPE.SENSOR_NOTIFICATION:
         this.initBinarySensor(node, binarySensorValueId);
         break;
 


### PR DESCRIPTION
Ecolink door sensors are being classified as "Sensor Notification" which
wasn't being handled at all.  This change handles "Sensor Notification"
objects the same way as "Sensor Binary" objects.  The end result is
that there is an active/inactive value reported from the door sensor to
the gateway interface.

I would really prefer to have proper door sensor support in the gateway UI, so any tips on getting there would be appreciated (I'm assuming no zwave door sensors are supported currently, since the `@type` is never classified as "DoorSensor").