### PR TITLE
Support alarm command-class door sensors

### DIFF
--- a/zwave-property.js
+++ b/zwave-property.js
@@ -82,6 +82,16 @@ class ZWaveProperty extends Property {
     return [motion, motion.toString()];
   }
 
+  parseAccessControlZwValue(zwData) {
+    // zwData for my door sensor can be:
+    // - Clear
+    // - Door/Window Open
+    // - Door/Window Closed
+    // (not sure if this is standard or device specific)
+    let open = !!zwData.match(/Open/i)
+    return [open, zwData]
+  }
+
   parseAlarmTamperZwValue(zwData) {
     let tamper = this.value;
     switch (zwData) {


### PR DESCRIPTION
Adds DoorSensor capability when the Alarm_Access_Control type is present on a node.

This works great in the UI, except I get this extraneous "On" proprerty from the `BinarySensor` generic type.  Do the other device types have this issue or is there some other thing type I should be setting this as (Maybe DoorSensor or MultiSensor should be the root type?