### PR TITLE
Remove calls to zwave.writeConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zwave-adapter",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zwave-adapter",
   "display_name": "Z-Wave",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Z-Wave adapter plugin for Mozilla WebThings Gateway",
   "author": "Mozilla IoT",
   "main": "index.js",

--- a/zwave-adapter.js
+++ b/zwave-adapter.js
@@ -157,7 +157,6 @@ class ZWaveAdapter extends Adapter {
     if (node.nodeId > 1) {
       zwaveClassifier.classify(node);
       super.handleDeviceAdded(node);
-      this.writeConfigDeferred();
     }
   }
 
@@ -182,7 +181,6 @@ class ZWaveAdapter extends Adapter {
     console.log('Scan complete');
     this.ready = true;
     this.dump();
-    this.writeConfigDeferred();
   }
 
   nodeAdded(nodeId) {
@@ -267,7 +265,6 @@ class ZWaveAdapter extends Adapter {
     if (node) {
       node.lastStatus = 'removed';
       this.handleDeviceRemoved(node);
-      this.writeConfigDeferred();
     }
   }
 
@@ -378,31 +375,6 @@ class ZWaveAdapter extends Adapter {
     const node = this.nodes[nodeId];
     if (node) {
       node.zwValueRemoved(comClass, valueInstance, valueIndex);
-    }
-  }
-
-  writeConfig() {
-    console.log('Writing ZWave configuration');
-    this.zwave.writeConfig();
-  }
-
-  writeConfigDeferred() {
-    // In order to reduce the number of times we rewrite the device info
-    // we defer writes for a time.
-
-    if (DEBUG_flow || process.env.NODE_ENV === 'test') {
-      this.writeConfig();
-    } else {
-      const timeoutSeconds = 120;
-
-      if (this.writeConfigTimeout) {
-        // already a timeout setup.
-        return;
-      }
-      this.writeConfigTimeout = setTimeout(() => {
-        this.writeConfigTimeout = null;
-        this.writeConfig();
-      }, timeoutSeconds * 1000);
     }
   }
 

--- a/zwave-node.js
+++ b/zwave-node.js
@@ -314,22 +314,6 @@ class ZWaveNode extends Device {
         property.updating = false;
       }
     }
-
-    if (this.canSleep) {
-      // For battery powered devices, we want to write out the
-      // configuration whenever a property change occurs. This
-      // ensures that when we start up we'll have the best idea
-      // of the last state. For mains powered devices, we'll get
-      // the information during the scan, so we don't need to
-      // save it here.
-      const valueId = property.valueId;
-      if (valueId) {
-        const zwValue = this.zwValues[valueId];
-        if (zwValue) {
-          this.adapter.writeConfigDeferred();
-        }
-      }
-    }
   }
 
   static oneLineHeader(line) {


### PR DESCRIPTION
zwave.writeConfig was deprecated with the release of OpenZWave 1.6
and is no longer available.