### PR TITLE
Adding Support for Heiman Gas Detector

### DIFF
--- a/zwave-classifier.js
+++ b/zwave-classifier.js
@@ -78,6 +78,7 @@ const NOTIFICATION_CO_DETECTOR = 2;
 const NOTIFICATION_WATER_LEAK = 5;
 const NOTIFICATION_ACCESS_CONTROL = 6;
 const NOTIFICATION_HOME_SECURITY = 7;
+const NOTIFICATION_COMBUSTIBLE_GAS = 18;
 
 const NOTIFICATION_SENSOR = {
   [NOTIFICATION_SMOKE_DETECTOR]: {// 1
@@ -145,6 +146,19 @@ const NOTIFICATION_SENSOR = {
       readOnly: true,
     },
     valueMap: ['Clear', 'Motion'],
+  },
+  [NOTIFICATION_COMBUSTIBLE_GAS]: {// 18
+    name: 'combustible_gas',
+    '@type': ['Alarm'],
+    propertyName: 'combustible_gas',
+    propertyDescr: {
+      '@type': 'AlarmProperty',
+      type: 'boolean',
+      label: 'Combustible Gas',
+      description: 'Combustible Gas Detector',
+      readOnly: true,
+    },
+    valueListMap: [false, true],
   },
 };
 


### PR DESCRIPTION
Adding support for the Alarm class (113) of the Combustible Gas type (18):

![image](https://user-images.githubusercontent.com/20259378/68077106-56991f80-fdbe-11e9-8e4f-ea0755aeca69.png)

I have tested it using Heiman sensor directly on a gateway running in the raspberry pi. 

**Note:**
I tried to follow the guide for [adding a new device](https://github.com/mozilla-iot/zwave-adapter/blob/master/Adding-a-new-device.md) but the `cli` tool is not able to connect to my gateway. It would be great if there was an option in the gateway menu for developer (gui) to export the json file of the available devices. This would ease a lot the generation of the unit tests. At the moment, I am unable to get this json file, that's why I couldn't add a unit test.
